### PR TITLE
Cleanup B: green test suite

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,54 @@
+name: Tests
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - main
+
+jobs:
+  phpunit:
+    name: PHPUnit (PHP 8.3)
+    runs-on: ubuntu-latest
+
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -proot"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+
+    env:
+      WP_TESTS_DIR: /tmp/wordpress-tests-lib
+      WP_CORE_DIR: /tmp/wordpress
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up PHP 8.3
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          extensions: mysqli
+          coverage: none
+          tools: composer
+
+      - name: Install the WordPress test suite
+        run: |
+          chmod +x bin/install-wp-tests.sh
+          bash bin/install-wp-tests.sh wordpress_test root root 127.0.0.1 latest
+
+      - name: Install Composer dependencies
+        # --no-scripts skips the bot-pattern regeneration (post-update-cmd); dev
+        # deps (phpunit + polyfills) are fetched here since they are not committed.
+        run: composer install --prefer-dist --no-progress --no-scripts
+
+      - name: Run PHPUnit
+        run: composer test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,8 +46,10 @@ jobs:
           bash bin/install-wp-tests.sh wordpress_test root root 127.0.0.1 latest
 
       - name: Install Composer dependencies
-        # --no-scripts skips the bot-pattern regeneration (post-update-cmd); dev
-        # deps (phpunit + polyfills) are fetched here since they are not committed.
+        # --no-scripts is a safety net: with composer.lock committed and in sync,
+        # post-update-cmd (bot-pattern regeneration) won't fire on install anyway,
+        # but it guards against a drifted lock silently mutating data/bot-patterns.php
+        # in CI. Dev deps (phpunit + polyfills) are fetched here (not committed).
         run: composer install --prefer-dist --no-progress --no-scripts
 
       - name: Run PHPUnit

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -1,0 +1,316 @@
+#!/usr/bin/env bash
+
+# See https://raw.githubusercontent.com/wp-cli/scaffold-command/master/templates/install-wp-tests.sh
+
+# Set up colors for output
+RED="\033[0;31m"
+GREEN="\033[0;32m"
+YELLOW="\033[0;33m"
+CYAN="\033[0;36m"
+RESET="\033[0m"
+
+if [ $# -lt 3 ]; then
+	echo -e "${YELLOW}Usage:${RESET} $0 <db-name> <db-user> <db-pass> [db-host] [wp-version] [skip-database-creation]"
+	exit 1
+fi
+
+DB_NAME=$1
+DB_USER=$2
+DB_PASS=$3
+DB_HOST=${4-localhost}
+WP_VERSION=${5-latest}
+SKIP_DB_CREATE=${6-false}
+
+TMPDIR=${TMPDIR-/tmp}
+TMPDIR=$(echo $TMPDIR | sed -e "s/\/$//")
+WP_TESTS_DIR=${WP_TESTS_DIR-$TMPDIR/wordpress-tests-lib}
+WP_TESTS_FILE="$WP_TESTS_DIR"/includes/functions.php
+WP_CORE_DIR=${WP_CORE_DIR-$TMPDIR/wordpress}
+WP_CORE_FILE="$WP_CORE_DIR"/wp-settings.php
+
+download() {
+    if command -v curl > /dev/null 2>&1; then
+        curl -L -s "$1" > "$2";
+        return $?
+    elif command -v wget > /dev/null 2>&1; then
+        wget -nv -O "$2" "$1"
+        return $?
+    else
+        echo -e "${RED}Error: Neither curl nor wget is installed.${RESET}"
+        exit 1
+    fi
+}
+
+check_for_updates() {
+	local remote_url="https://raw.githubusercontent.com/wp-cli/scaffold-command/main/templates/install-wp-tests.sh"
+	local tmp_script="$TMPDIR/install-wp-tests.sh.latest"
+
+	if ! download "$remote_url" "$tmp_script"; then
+		echo -e "${YELLOW}Warning: Failed to download the latest version of the script for update check.${RESET}"
+		return
+	fi
+
+	if [ ! -f "$tmp_script" ] || [ ! -s "$tmp_script" ]; then
+		echo -e "${YELLOW}Warning: Downloaded script is missing or empty, cannot check for updates.${RESET}"
+		rm -f "$tmp_script"
+		return
+	fi
+
+	local local_hash=""
+	local remote_hash=""
+
+	if command -v shasum > /dev/null; then
+		local_hash=$(shasum -a 256 "$0" | awk '{print $1}')
+		remote_hash=$(shasum -a 256 "$tmp_script" | awk '{print $1}')
+	elif command -v sha256sum > /dev/null; then
+		local_hash=$(sha256sum "$0" | awk '{print $1}')
+		remote_hash=$(sha256sum "$tmp_script" | awk '{print $1}')
+	else
+		echo -e "${YELLOW}Warning: Could not find shasum or sha256sum to check for script updates.${RESET}"
+		rm "$tmp_script"
+		return
+	fi
+
+	rm "$tmp_script"
+
+	if [ "$local_hash" != "$remote_hash" ]; then
+		echo -e "${YELLOW}Warning: A newer version of this script is available at $remote_url${RESET}"
+	fi
+}
+# Allow disabling the update check by setting WP_INSTALL_TESTS_SKIP_UPDATE_CHECK=true in the environment.
+if [ "${WP_INSTALL_TESTS_SKIP_UPDATE_CHECK:-false}" != "true" ]; then
+	check_for_updates
+fi
+
+if [[ $WP_VERSION =~ ^[0-9]+\.[0-9]+\-(beta|RC)[0-9]+$ ]]; then
+	WP_BRANCH=${WP_VERSION%\-*}
+	WP_TESTS_TAG="branches/$WP_BRANCH"
+elif [[ $WP_VERSION =~ ^[0-9]+\.[0-9]+$ ]]; then
+	WP_TESTS_TAG="branches/$WP_VERSION"
+elif [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0-9]+ ]]; then
+	if [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0] ]]; then
+		# version x.x.0 means the first release of the major version, so strip off the .0 and download version x.x
+		WP_TESTS_TAG="tags/${WP_VERSION%??}"
+	else
+		WP_TESTS_TAG="tags/$WP_VERSION"
+	fi
+elif [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
+	WP_TESTS_TAG="trunk"
+else
+	# http serves a single offer, whereas https serves multiple. we only want one
+	download http://api.wordpress.org/core/version-check/1.7/ /tmp/wp-latest.json
+	LATEST_VERSION=$(grep -oE '"version":"[^"]*' /tmp/wp-latest.json | head -n 1 | sed 's/"version":"//')
+	if [[ -z "$LATEST_VERSION" ]]; then
+		echo -e "${RED}Error: Latest WordPress version could not be found.${RESET}"
+		exit 1
+	fi
+	# The version-check endpoint returns major.minor (e.g., 6.9), but GitHub tags include the patch version (e.g., 6.9.0)
+	if [[ $LATEST_VERSION =~ ^[0-9]+\.[0-9]+$ ]]; then
+		LATEST_VERSION="${LATEST_VERSION}.0"
+	fi
+	WP_TESTS_TAG="tags/$LATEST_VERSION"
+fi
+
+set -ex
+
+install_wp() {
+
+	if [ -f $WP_CORE_FILE ]; then
+		echo -e "${CYAN}WordPress is already installed.${RESET}"
+		return;
+	fi
+
+	echo -e "${CYAN}Installing WordPress...${RESET}"
+
+	rm -rf $WP_CORE_DIR
+	mkdir -p $WP_CORE_DIR
+
+	if [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
+		download https://github.com/WordPress/wordpress/archive/refs/heads/master.tar.gz $TMPDIR/wordpress.tar.gz
+		tar --strip-components=1 -zxmf $TMPDIR/wordpress.tar.gz -C $WP_CORE_DIR
+	else
+		if [ $WP_VERSION == 'latest' ]; then
+			local ARCHIVE_NAME='latest'
+		elif [[ $WP_VERSION =~ [0-9]+\.[0-9]+ ]]; then
+			# https serves multiple offers, whereas http serves single.
+			download https://api.wordpress.org/core/version-check/1.7/ $TMPDIR/wp-latest.json
+			if [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0] ]]; then
+				# version x.x.0 means the first release of the major version, so strip off the .0 and download version x.x
+				LATEST_VERSION=${WP_VERSION%??}
+			else
+				# otherwise, scan the releases and get the most up to date minor version of the major release
+				local VERSION_ESCAPED=`echo $WP_VERSION | sed 's/\./\\\\./g'`
+				LATEST_VERSION=$(grep -o '"version":"'$VERSION_ESCAPED'[^"]*' $TMPDIR/wp-latest.json | sed 's/"version":"//' | head -1)
+			fi
+			if [[ -z "$LATEST_VERSION" ]]; then
+				local ARCHIVE_NAME="wordpress-$WP_VERSION"
+			else
+				local ARCHIVE_NAME="wordpress-$LATEST_VERSION"
+			fi
+		else
+			local ARCHIVE_NAME="wordpress-$WP_VERSION"
+		fi
+		download https://wordpress.org/${ARCHIVE_NAME}.tar.gz  $TMPDIR/wordpress.tar.gz
+		tar --strip-components=1 -zxmf $TMPDIR/wordpress.tar.gz -C $WP_CORE_DIR
+	fi
+	echo -e "${GREEN}WordPress installed successfully.${RESET}"
+}
+
+install_test_suite() {
+	# portable in-place argument for both GNU sed and Mac OSX sed
+	if [[ $(uname -s) == 'Darwin' ]]; then
+		local ioption='-i.bak'
+	else
+		local ioption='-i'
+	fi
+
+	# set up testing suite if it doesn't yet exist or only partially exists
+	if [ ! -f $WP_TESTS_FILE ]; then
+		echo -e "${CYAN}Installing test suite...${RESET}"
+		# set up testing suite
+		rm -rf $WP_TESTS_DIR
+		mkdir -p $WP_TESTS_DIR
+
+		if [[ $WP_TESTS_TAG == 'trunk' ]]; then
+			ref=trunk
+			archive_url="https://github.com/WordPress/wordpress-develop/archive/refs/heads/${ref}.tar.gz"
+		elif [[ $WP_TESTS_TAG == branches/* ]]; then
+			ref=${WP_TESTS_TAG#branches/}
+			archive_url="https://github.com/WordPress/wordpress-develop/archive/refs/heads/${ref}.tar.gz"
+		else
+			ref=${WP_TESTS_TAG#tags/}
+			archive_url="https://github.com/WordPress/wordpress-develop/archive/refs/tags/${ref}.tar.gz"
+		fi
+
+		if [ -z "$ref" ]; then
+			echo -e "${RED}Error:${RESET} Unable to determine git reference from WP_TESTS_TAG: $WP_TESTS_TAG"
+			exit 1
+		fi
+
+		download "${archive_url}" "$TMPDIR/wordpress-develop.tar.gz"
+
+		# Validate that the tarball was downloaded correctly before extracting
+		if [ ! -s "$TMPDIR/wordpress-develop.tar.gz" ]; then
+			echo -e "${RED}Error:${RESET} Downloaded test suite archive is missing or empty: $TMPDIR/wordpress-develop.tar.gz"
+			exit 1
+		fi
+
+		if ! tar -tzf "$TMPDIR/wordpress-develop.tar.gz" >/dev/null 2>&1; then
+			echo -e "${RED}Error:${RESET} Downloaded test suite archive is not a valid tar.gz file: $TMPDIR/wordpress-develop.tar.gz"
+			exit 1
+		fi
+
+		tar -zxmf "$TMPDIR/wordpress-develop.tar.gz" -C "$TMPDIR"
+		mv "$TMPDIR/wordpress-develop-${ref}/tests/phpunit/includes" "$WP_TESTS_DIR"/
+		mv "$TMPDIR/wordpress-develop-${ref}/tests/phpunit/data" "$WP_TESTS_DIR"/
+		rm -rf "$TMPDIR/wordpress-develop-${ref}"
+		rm "$TMPDIR/wordpress-develop.tar.gz"
+		echo -e "${GREEN}Test suite installed.${RESET}"
+	else
+		echo -e "${CYAN}Test suite is already installed.${RESET}"
+	fi
+
+	if [ ! -f "$WP_TESTS_DIR"/wp-tests-config.php ]; then
+		echo -e "${CYAN}Configuring test suite...${RESET}"
+		if [[ $WP_TESTS_TAG == 'trunk' ]]; then
+			ref=trunk
+		elif [[ $WP_TESTS_TAG == branches/* ]]; then
+			ref=${WP_TESTS_TAG#branches/}
+		else
+			ref=${WP_TESTS_TAG#tags/}
+		fi
+
+		if [ -z "$ref" ]; then
+			echo -e "${RED}Error:${RESET} Unable to determine git reference from WP_TESTS_TAG: $WP_TESTS_TAG"
+			exit 1
+		fi
+
+		download https://raw.githubusercontent.com/WordPress/wordpress-develop/${ref}/wp-tests-config-sample.php "$WP_TESTS_DIR"/wp-tests-config.php
+		# remove all forward slashes in the end
+		WP_CORE_DIR=$(echo $WP_CORE_DIR | sed "s:/\+$::")
+		# escape special sed replacement characters in $WP_CORE_DIR (backslash, pipe, ampersand)
+		WP_CORE_DIR_ESCAPED=$(printf '%s' "$WP_CORE_DIR" | sed 's/[\\|&]/\\&/g')
+		sed $ioption "s|dirname( __FILE__ ) . '/src/'|'${WP_CORE_DIR_ESCAPED}/'|" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s|__DIR__ . '/src/'|'${WP_CORE_DIR_ESCAPED}/'|" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/yourusernamehere/$DB_USER/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/yourpasswordhere/$DB_PASS/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s|localhost|${DB_HOST}|" "$WP_TESTS_DIR"/wp-tests-config.php
+		echo -e "${GREEN}Test suite configured.${RESET}"
+	else
+		echo -e "${CYAN}Test suite is already configured.${RESET}"
+	fi
+
+}
+
+recreate_db() {
+	shopt -s nocasematch
+	if [[ $1 =~ ^(y|yes)$ ]]
+	then
+		echo -e "${CYAN}Recreating the database ($DB_NAME)...${RESET}"
+		if command -v mariadb-admin > /dev/null 2>&1; then
+			mariadb-admin drop $DB_NAME -f --user="$DB_USER" --password="$DB_PASS"$EXTRA
+		else
+			mysqladmin drop $DB_NAME -f --user="$DB_USER" --password="$DB_PASS"$EXTRA
+		fi
+		create_db
+		echo -e "${GREEN}Database ($DB_NAME) recreated.${RESET}"
+	else
+		echo -e "${YELLOW}Leaving the existing database ($DB_NAME) in place.${RESET}"
+	fi
+	shopt -u nocasematch
+}
+
+create_db() {
+	if command -v mariadb-admin > /dev/null 2>&1; then
+		mariadb-admin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
+	else
+		mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
+	fi
+}
+
+install_db() {
+
+	if [ ${SKIP_DB_CREATE} = "true" ]; then
+		echo -e "${YELLOW}Skipping database creation.${RESET}"
+		return 0
+	fi
+
+	# parse DB_HOST for port or socket references
+	local PARTS=(${DB_HOST//\:/ })
+	local DB_HOSTNAME=${PARTS[0]};
+	local DB_SOCK_OR_PORT=${PARTS[1]};
+	local EXTRA=""
+
+	if ! [ -z $DB_HOSTNAME ] ; then
+		if [ $(echo $DB_SOCK_OR_PORT | grep -e '^[0-9]\{1,\}$') ]; then
+			EXTRA=" --host=$DB_HOSTNAME --port=$DB_SOCK_OR_PORT --protocol=tcp"
+		elif ! [ -z $DB_SOCK_OR_PORT ] ; then
+			EXTRA=" --socket=$DB_SOCK_OR_PORT"
+		elif ! [ -z $DB_HOSTNAME ] ; then
+			EXTRA=" --host=$DB_HOSTNAME --protocol=tcp"
+		fi
+	fi
+
+	# create database
+	if command -v mariadb > /dev/null 2>&1; then
+		local DB_CLIENT='mariadb'
+	else
+		local DB_CLIENT='mysql'
+	fi
+	if $DB_CLIENT --user="$DB_USER" --password="$DB_PASS"$EXTRA --execute='show databases;' | grep -q "^$DB_NAME$";
+	then
+		echo -e "${YELLOW}Reinstalling will delete the existing test database ($DB_NAME)${RESET}"
+		read -p 'Are you sure you want to proceed? [y/N]: ' DELETE_EXISTING_DB
+		recreate_db $DELETE_EXISTING_DB
+	else
+		echo -e "${CYAN}Creating database ($DB_NAME)...${RESET}"
+		create_db
+		echo -e "${GREEN}Database ($DB_NAME) created.${RESET}"
+	fi
+}
+
+install_wp
+install_test_suite
+install_db
+echo -e "${GREEN}Done.${RESET}"

--- a/src/AdminRestApi.php
+++ b/src/AdminRestApi.php
@@ -668,7 +668,7 @@ class AdminRestApi {
 	 *
 	 * @param WP_REST_Request $request The incoming request.
 	 *
-	 * @return WP_REST_Response Available post types, taxonomies, and authors that have data.
+	 * @return WP_REST_Response Available post types and taxonomies that have data.
 	 */
 	public function get_filters( WP_REST_Request $request ): WP_REST_Response {
 		$cached = get_transient( 'mai_analytics_admin_filters' );
@@ -730,35 +730,9 @@ class AdminRestApi {
 			}
 		}
 
-		// Authors of posts with views. The Posts-tab filter narrows posts by
-		// their author, so the relevant set is "authors who have viewed posts"
-		// rather than "authors whose own /author/ archive was tracked" (often
-		// zero — author archives are rarely linked and often disabled by SEO
-		// plugins, plus tracking is skipped for visitors with edit_posts).
-		$authors     = [];
-		$author_rows = $wpdb->get_results(
-			"SELECT DISTINCT u.ID, u.display_name
-			 FROM $wpdb->users u
-			 INNER JOIN $wpdb->posts p ON u.ID = p.post_author
-			 INNER JOIN $wpdb->postmeta pm ON p.ID = pm.post_id
-			 WHERE pm.meta_key = 'mai_views'
-			   AND CAST(pm.meta_value AS UNSIGNED) > 0
-			   AND p.post_status = 'publish'
-			   AND p.post_type IN ('{$type_list}')
-			 ORDER BY u.display_name ASC"
-		);
-
-		foreach ( $author_rows as $author ) {
-			$authors[] = [
-				'id'   => (int) $author->ID,
-				'name' => $author->display_name,
-			];
-		}
-
 		$payload = [
 			'post_types' => $post_types,
 			'taxonomies' => $taxonomies,
-			'authors'    => $authors,
 		];
 
 		set_transient( 'mai_analytics_admin_filters', $payload, 5 * MINUTE_IN_SECONDS );

--- a/src/BotFilter.php
+++ b/src/BotFilter.php
@@ -5,6 +5,34 @@ namespace Mai\Analytics;
 class BotFilter {
 
 	/**
+	 * Generic non-browser HTTP client substrings.
+	 *
+	 * data/bot-patterns.php is auto-generated from Matomo's device-detector
+	 * list (see its "do not edit manually" header) and only covers named
+	 * crawlers/bots, not generic command-line or script HTTP clients. Real
+	 * page views never come from these UAs, so they're merged in here
+	 * instead of hand-editing the generated file. Kept deliberately
+	 * conservative (unambiguous, slash-qualified where needed) to avoid
+	 * false-positiving on real browser or app traffic.
+	 *
+	 * @var string[]
+	 */
+	const GENERIC_HTTP_CLIENT_PATTERNS = [
+		'curl/',
+		'wget',
+		'python-requests',
+		'python-urllib',
+		'go-http-client',
+		'libwww-perl',
+		'java/',
+		'guzzlehttp',
+		'node-fetch',
+		'axios/',
+		'scrapy',
+		'httpclient',
+	];
+
+	/**
 	 * Checks if a user-agent string belongs to a known bot.
 	 *
 	 * @param string|null $user_agent The user-agent header value.
@@ -32,6 +60,7 @@ class BotFilter {
 	 */
 	public static function get_patterns(): array {
 		$patterns = require MAI_ANALYTICS_PLUGIN_DIR . 'data/bot-patterns.php';
+		$patterns = array_merge( $patterns, self::GENERIC_HTTP_CLIENT_PATTERNS );
 
 		return apply_filters( 'mai_analytics_bot_patterns', $patterns );
 	}

--- a/src/BotFilter.php
+++ b/src/BotFilter.php
@@ -12,8 +12,12 @@ class BotFilter {
 	 * crawlers/bots, not generic command-line or script HTTP clients. Real
 	 * page views never come from these UAs, so they're merged in here
 	 * instead of hand-editing the generated file. Kept deliberately
-	 * conservative (unambiguous, slash-qualified where needed) to avoid
-	 * false-positiving on real browser or app traffic.
+	 * conservative — only unambiguous CLI/scraper tools, and NOT the default
+	 * user-agents of general-purpose HTTP libraries (Go, Node, Java, Guzzle,
+	 * Apache HttpClient), which legitimate app/backend integrations send and
+	 * which would otherwise silently undercount real `source=app` traffic.
+	 *
+	 * @since 1.3.0
 	 *
 	 * @var string[]
 	 */
@@ -22,13 +26,7 @@ class BotFilter {
 		'wget',
 		'python-requests',
 		'python-urllib',
-		'go-http-client',
 		'libwww-perl',
-		'java/',
-		'guzzlehttp',
-		'node-fetch',
-		'axios/',
-		'scrapy',
 	];
 
 	/**

--- a/src/BotFilter.php
+++ b/src/BotFilter.php
@@ -29,7 +29,6 @@ class BotFilter {
 		'node-fetch',
 		'axios/',
 		'scrapy',
-		'httpclient',
 	];
 
 	/**

--- a/src/ProviderSync.php
+++ b/src/ProviderSync.php
@@ -393,8 +393,10 @@ class ProviderSync {
 	 * sites every object's permalink is a bare `/?p=123`-style URL with the
 	 * same path (`/`) and a distinguishing query string; dropping the query
 	 * (as a prior version of this method did) collapsed every object onto
-	 * one path and silently discarded all but the last from the warm/sync
-	 * batch. Preserving the query keeps objects distinct there. On
+	 * one path — so process_warm_batch() (keyed by path) dropped all but the
+	 * last colliding object, and process_batch() cross-contaminated every
+	 * colliding object with the same (wrong) counts. Preserving the query
+	 * keeps objects distinct there. On
 	 * pretty-permalink sites there is no query string, so this is a no-op
 	 * and behavior is unchanged. Returns null if the object type is
 	 * unrecognized or the URL cannot be resolved.

--- a/src/ProviderSync.php
+++ b/src/ProviderSync.php
@@ -388,12 +388,26 @@ class ProviderSync {
 	/**
 	 * Gets the URL path for a buffer object.
 	 *
-	 * Resolves the object's permalink and extracts just the path component.
-	 * Returns null if the object type is unrecognized or the URL cannot be resolved.
+	 * Resolves the object's permalink and extracts the path (plus query string,
+	 * when present) so each object maps to a unique key. On plain-permalink
+	 * sites every object's permalink is a bare `/?p=123`-style URL with the
+	 * same path (`/`) and a distinguishing query string; dropping the query
+	 * (as a prior version of this method did) collapsed every object onto
+	 * one path and silently discarded all but the last from the warm/sync
+	 * batch. Preserving the query keeps objects distinct there. On
+	 * pretty-permalink sites there is no query string, so this is a no-op
+	 * and behavior is unchanged. Returns null if the object type is
+	 * unrecognized or the URL cannot be resolved.
+	 *
+	 * Note: this only prevents objects from being dropped/cross-contaminated
+	 * during warm/sync. Whether the provider (e.g. Matomo) actually has
+	 * matching view data for a query-string URL on a plain-permalink site is
+	 * a separate, out-of-scope concern.
 	 *
 	 * @param object $obj Buffer row with object_id, object_type, and object_key properties.
 	 *
-	 * @return string|null The URL path (e.g., '/some-post/'), or null on failure.
+	 * @return string|null The URL path, optionally with a query string (e.g.
+	 *                      '/some-post/' or '/?p=123'), or null on failure.
 	 */
 	private static function get_object_path( object $obj ): ?string {
 		$url = match ( $obj->object_type ) {
@@ -408,9 +422,10 @@ class ProviderSync {
 			return null;
 		}
 
-		$path = wp_parse_url( $url, PHP_URL_PATH );
+		$path  = wp_parse_url( $url, PHP_URL_PATH ) ?: '/';
+		$query = wp_parse_url( $url, PHP_URL_QUERY );
 
-		return $path ?: '/';
+		return $query ? "{$path}?{$query}" : $path;
 	}
 
 	/**

--- a/tests/test-admin-rest-api.php
+++ b/tests/test-admin-rest-api.php
@@ -17,8 +17,7 @@ class Test_Admin_REST_API extends WP_UnitTestCase {
 	}
 
 	public function tearDown(): void {
-		global $wpdb, $wp_rest_server;
-		$wpdb->query( 'TRUNCATE TABLE ' . Database::get_table_name() );
+		global $wp_rest_server;
 		$wp_rest_server = null;
 		parent::tearDown();
 	}

--- a/tests/test-admin-rest-api.php
+++ b/tests/test-admin-rest-api.php
@@ -245,8 +245,11 @@ class Test_Admin_REST_API extends WP_UnitTestCase {
 	public function test_search_authors(): void {
 		wp_set_current_user( self::factory()->user->create( [ 'role' => 'editor' ] ) );
 
+		// Author search surfaces authors of viewed posts (matches get_filters()),
+		// not authors with their own /author/ archive tracked.
 		$user_id = self::factory()->user->create( [ 'display_name' => 'Jane Analytics' ] );
-		update_user_meta( $user_id, 'mai_views', 10 );
+		$post_id = self::factory()->post->create( [ 'post_status' => 'publish', 'post_author' => $user_id ] );
+		update_post_meta( $post_id, 'mai_views', 10 );
 
 		$request = new WP_REST_Request( 'GET', '/mai-analytics/v1/admin/search' );
 		$request->set_param( 'type', 'author' );

--- a/tests/test-bot-filter.php
+++ b/tests/test-bot-filter.php
@@ -33,4 +33,24 @@ class Test_Bot_Filter extends WP_UnitTestCase {
 		add_filter( 'mai_analytics_bot_patterns', fn( $p ) => array_merge( $p, [ 'MyCustomBot' ] ) );
 		$this->assertTrue( BotFilter::is_bot( 'MyCustomBot/1.0' ) );
 	}
+
+	/**
+	 * Coverage for the supplementary generic-client patterns (curl is covered by
+	 * test_detects_curl). Guards against a typo or accidental removal, and against
+	 * the list drifting back toward the ambiguous library UAs we deliberately excluded.
+	 *
+	 * @dataProvider generic_http_client_provider
+	 */
+	public function test_detects_generic_http_clients( string $user_agent ): void {
+		$this->assertTrue( BotFilter::is_bot( $user_agent ) );
+	}
+
+	public static function generic_http_client_provider(): array {
+		return [
+			'wget'            => [ 'Wget/1.21.3 (linux-gnu)' ],
+			'python-requests' => [ 'python-requests/2.31.0' ],
+			'python-urllib'   => [ 'Python-urllib/3.9' ],
+			'libwww-perl'     => [ 'libwww-perl/6.67' ],
+		];
+	}
 }

--- a/tests/test-cron.php
+++ b/tests/test-cron.php
@@ -29,7 +29,14 @@ class Test_Cron extends WP_UnitTestCase {
 	}
 
 	public function test_cron_skips_recent_sync(): void {
-		update_option( 'mai_analytics_synced', time() );
+		// Set the marker a bit into the future (not just "now") so the view
+		// inserted below is unambiguously <= the sync boundary even if a
+		// wall-clock second ticks between this line and Database::insert_view().
+		// A same-second marker is boundary-fragile: viewed_at uses its own
+		// current_time() call, so it can land one second after this time()
+		// call, flipping the strict `viewed_at > $last_sync_date` comparison
+		// in Sync::sync() from excluded to included and failing the test.
+		update_option( 'mai_analytics_synced', time() + MINUTE_IN_SECONDS );
 
 		$cron    = new Cron();
 		$post_id = self::factory()->post->create();

--- a/tests/test-cron.php
+++ b/tests/test-cron.php
@@ -12,8 +12,6 @@ class Test_Cron extends WP_UnitTestCase {
 	}
 
 	public function tearDown(): void {
-		global $wpdb;
-		$wpdb->query( 'TRUNCATE TABLE ' . Database::get_table_name() );
 		delete_option( 'mai_analytics_synced' );
 		delete_option( 'mai_analytics_settings' );
 		delete_option( 'mai_analytics_provider_error' );

--- a/tests/test-database.php
+++ b/tests/test-database.php
@@ -9,12 +9,6 @@ class Test_Database extends WP_UnitTestCase {
 		Database::create_table();
 	}
 
-	public function tearDown(): void {
-		global $wpdb;
-		$wpdb->query( 'TRUNCATE TABLE ' . Database::get_table_name() );
-		parent::tearDown();
-	}
-
 	public function test_table_exists(): void {
 		global $wpdb;
 		$table  = Database::get_table_name();

--- a/tests/test-meta.php
+++ b/tests/test-meta.php
@@ -2,6 +2,17 @@
 
 class Test_Meta extends WP_UnitTestCase {
 
+	/**
+	 * WP core's tearDown() calls unregister_all_meta_keys() after every test
+	 * in the suite, but Meta::register_meta() only ever runs once (hooked to
+	 * `init`, which fires once per process). Re-register before each test so
+	 * these assertions don't depend on running first in the process.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		( new \Mai\Analytics\Meta() )->register_meta();
+	}
+
 	public function test_post_meta_registered(): void {
 		$registered = get_registered_meta_keys( 'post' );
 

--- a/tests/test-provider-sync.php
+++ b/tests/test-provider-sync.php
@@ -107,6 +107,34 @@ class Test_Provider_Sync extends WP_UnitTestCase {
 		] );
 	}
 
+	public function test_sync_requests_distinct_paths_per_object(): void {
+		// Regression guard for the plain-permalink data-loss fix (get_object_path()
+		// preserving the query string). The WP test env uses plain permalinks, so
+		// both posts' permalinks are '/?p=N' — same path, different query. Each
+		// object must map to a UNIQUE provider path; if a refactor drops the query
+		// again, both collapse to '/' and only one path reaches the provider.
+		$captured_paths = null;
+		$this->register_mock_provider( 100, true, 50, function ( $paths, $windows ) use ( &$captured_paths ) {
+			$captured_paths = $paths;
+			$out = [];
+			foreach ( $paths as $path ) {
+				foreach ( $windows as $name => $_range ) {
+					$out[ $path ][ $name ] = 100;
+				}
+			}
+			return $out;
+		} );
+
+		$post_a = self::factory()->post->create( [ 'post_status' => 'publish' ] );
+		$post_b = self::factory()->post->create( [ 'post_status' => 'publish' ] );
+		Database::insert_view( $post_a, 'post', 'web' );
+		Database::insert_view( $post_b, 'post', 'web' );
+
+		ProviderSync::sync();
+
+		$this->assertCount( 2, $captured_paths );
+	}
+
 	public function test_sync_reads_distinct_objects_from_buffer(): void {
 		$this->register_mock_provider( 100 );
 

--- a/tests/test-provider-sync.php
+++ b/tests/test-provider-sync.php
@@ -26,8 +26,6 @@ class Test_Provider_Sync extends WP_UnitTestCase {
 	}
 
 	public function tearDown(): void {
-		global $wpdb;
-		$wpdb->query( 'TRUNCATE TABLE ' . Database::get_table_name() );
 		delete_transient( 'mai_analytics_provider_syncing' );
 		remove_all_filters( 'mai_analytics_providers' );
 		remove_all_filters( 'mai_analytics_warm_skip_threshold' );

--- a/tests/test-providers-matomo.php
+++ b/tests/test-providers-matomo.php
@@ -96,18 +96,18 @@ class Test_Providers_Matomo extends WP_UnitTestCase {
 		$this->assertStringContainsString( '/post-b/', $entries[2]['pageUrl'] );
 		$this->assertStringContainsString( '/post-b/', $entries[3]['pageUrl'] );
 
-		// Trending sub-queries (period=day) come before all-time (period=week)
+		// Trending sub-queries (period=day) come before all-time (period=year)
 		// within each path's group.
 		$this->assertEquals( 'day',  $entries[0]['period'] );
-		$this->assertEquals( 'week', $entries[1]['period'] );
+		$this->assertEquals( 'year', $entries[1]['period'] );
 		$this->assertEquals( 'day',  $entries[2]['period'] );
-		$this->assertEquals( 'week', $entries[3]['period'] );
+		$this->assertEquals( 'year', $entries[3]['period'] );
 	}
 
 	/**
-	 * Empty start_date in a window must produce period=week, date=last{years*52}.
+	 * Empty start_date in a window must produce period=year, date=last{years}.
 	 */
-	public function test_empty_start_translates_to_weekly_period(): void {
+	public function test_empty_start_translates_to_yearly_period(): void {
 		// Force a known views_years so the assertion is stable.
 		add_filter( 'mai_analytics_views_years', fn() => 3 );
 
@@ -122,8 +122,8 @@ class Test_Providers_Matomo extends WP_UnitTestCase {
 		$urls = self::$captured[0]['body']['urls'] ?? [];
 		parse_str( $urls[0], $entry );
 
-		$this->assertEquals( 'week', $entry['period'] );
-		$this->assertEquals( 'last' . ( 3 * 52 ), $entry['date'] );
+		$this->assertEquals( 'year', $entry['period'] );
+		$this->assertEquals( 'last' . 3, $entry['date'] );
 	}
 
 	/**

--- a/tests/test-rest-api.php
+++ b/tests/test-rest-api.php
@@ -16,8 +16,7 @@ class Test_REST_API extends WP_UnitTestCase {
 	}
 
 	public function tearDown(): void {
-		global $wpdb, $wp_rest_server;
-		$wpdb->query( 'TRUNCATE TABLE ' . Database::get_table_name() );
+		global $wp_rest_server;
 		$wp_rest_server = null;
 		parent::tearDown();
 	}

--- a/tests/test-sync.php
+++ b/tests/test-sync.php
@@ -12,8 +12,6 @@ class Test_Sync extends WP_UnitTestCase {
 	}
 
 	public function tearDown(): void {
-		global $wpdb;
-		$wpdb->query( 'TRUNCATE TABLE ' . Database::get_table_name() );
 		delete_transient( 'mai_analytics_sync_lock' );
 		delete_transient( 'mai_analytics_syncing' );
 		parent::tearDown();

--- a/tests/test-sync.php
+++ b/tests/test-sync.php
@@ -29,7 +29,10 @@ class Test_Sync extends WP_UnitTestCase {
 
 	public function test_sync_increments_existing_views(): void {
 		$post_id = self::factory()->post->create();
-		update_post_meta( $post_id, 'mai_views', 10 );
+
+		// mai_views is a computed total (max(web+app, trending)), not an
+		// independently incremented counter — pre-seed the source of truth.
+		update_post_meta( $post_id, 'mai_views_web', 10 );
 
 		Database::insert_view( $post_id, 'post' );
 		Sync::sync();


### PR DESCRIPTION
## Cleanup B: green the test suite

Takes the PHPUnit suite from **29 failing (28 failures + 1 error) → 0** — green **and** verified stable across 100+ full-suite runs — and adds a CI gate so it can't silently regress.

### What's in it

**Test isolation (2 commits)** — replaced `TRUNCATE TABLE` teardowns with rollback-based isolation across 6 files. `TRUNCATE` is DDL → forces an implicit COMMIT → defeats `WP_UnitTestCase`'s per-test transaction rollback → cross-test row leakage. `Database::create_table()` in `setUp()` is an idempotent no-op, so rollback alone cleans up. Flipped 16 failures green.

**3 real bugs fixed in `src/`** (each surfaced by a failing test, fixed at the source rather than papered over — approved individually):
- **`ProviderSync::get_object_path()` preserves the query string.** On plain-permalink sites `get_permalink()` is `?p=123`, so `PHP_URL_PATH` collapsed every object to `/`; `process_warm_batch()`'s `$path_map[$path]` then dropped all but one object per warm batch (**silent data loss**). Pretty-permalink behavior is unchanged.
- **Removed a vestigial `authors` block from `AdminRestApi::get_filters()`** — a dead users→posts→postmeta query + payload key the dashboard no longer reads (it uses the `/admin/search` ajax endpoint now).
- **`BotFilter` now filters generic non-browser HTTP clients** (curl, wget, python-requests, …) via a documented supplementary list merged before the `mai_analytics_bot_patterns` filter; the auto-generated `data/bot-patterns.php` is untouched.

**10 drift test updates (3 commits)** — tests asserting superseded behavior updated to the correct expectations (Meta re-registration timing, Matomo all-time week→year archives, author-of-viewed-posts search model, `mai_views` computed-total). No assertion was weakened to force green.

**1 flake fix (1 commit)** — `test_cron_skips_recent_sync` sat exactly on the whole-second `viewed_at > last_sync_date` boundary; nudging the sync marker `+MINUTE_IN_SECONDS` makes the just-inserted view deterministically excluded. Verified 100/100 clean.

**CI (1 commit)** — `.github/workflows/tests.yml` runs `composer test` on PHP 8.3 + MySQL for every PR to `develop`/`main`, plus the canonical `bin/install-wp-tests.sh` the bootstrap already referenced.

### Notes
- The CI workflow can't be validated locally — it runs for the first time on this PR.
- The 3 `src/` bug fixes are user-facing and should get CHANGES.md lines when 1.3.0 is cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JthcnsngePWcnBD81Ggk3j
